### PR TITLE
fix test for nested obj on map init 

### DIFF
--- a/src/components/CityScopeJS/BaseMap/BaseMap.js
+++ b/src/components/CityScopeJS/BaseMap/BaseMap.js
@@ -30,6 +30,7 @@ export default function Map(props) {
     const [hoveredObj, setHoveredObj] = useState(null);
     const [access, setAccess] = useState(null);
     const [GEOGRID, setGEOGRID] = useState(null);
+    const [ABM, setABM] = useState({});
     const [loaded, setLoaded] = useState(false);
     const effectsRef = useRef();
     const deckGL = useRef();
@@ -89,6 +90,10 @@ export default function Map(props) {
 
         if (cityioData.access) {
             setAccess(_proccessAccessData(cityioData));
+        }
+
+        if (cityioData.ABM2) {
+            setABM(cityioData.ABM2);
         }
     }, [cityioData]);
 
@@ -158,14 +163,14 @@ export default function Map(props) {
 
     const layersKey = {
         ABM: ABMLayer({
-            data: cityioData.ABM2.trips,
+            data: ABM.trips,
             cityioData,
             ABMmode,
             zoomLevel: viewState.zoom,
             sliders,
         }),
         AGGREGATED_TRIPS: AggregatedTripsLayer({
-            data: cityioData.ABM2.trips,
+            data: ABM.trips,
             cityioData,
             ABMmode,
         }),


### PR DESCRIPTION
Fix by @yzheng1998 :

this function checks if the menu has the layer as a way to only load layers existing in this end point

``` 
const layerOrder = ["ABM", "AGGREGATED_TRIPS", "GRID", "ACCESS"];
    const _renderLayers = () => {
        let layers = [];
        for (var layer of layerOrder) {
            if (menu.includes(layer)) {
                layers.push(layersKey[layer]);
            }
        }
        return layers;
    };
```

however,
```  ABM: ABMLayer({
            data: cityioData.ABM.trips,
            cityioData,
            ABMmode,
            zoomLevel: viewState.zoom,
            sliders,
        }),
        AGGREGATED_TRIPS: AggregatedTripsLayer({
            data: cityioData.ABM.trips,
            cityioData,
            ABMmode,
```
this type of nested check would break the app, since if there is no cityioDATA.abm, [‘trips’] would not exist