### PR TITLE
Preparation for new CityIO version

### DIFF
--- a/src/Components/TableNameInput.js
+++ b/src/Components/TableNameInput.js
@@ -18,9 +18,9 @@ export default function TableNameInput({ setSelectedTable }) {
   // https://stackoverflow.com/a/27098801/860099
   function strToRemove(str, strToRemove) {
     let start = str.indexOf(strToRemove)
-    return (
+    let result =
       str.slice(0, start) + str.slice(start + strToRemove.length, str.length)
-    )
+    return result
   }
 
   useEffect(() => {
@@ -32,9 +32,8 @@ export default function TableNameInput({ setSelectedTable }) {
     const cityIOtableBaseUrl = settings.cityIO.baseURL
 
     axios.get(cityIOlistURL).then((res) => {
-      res.data.forEach((urlStr) => {
-        const tableName = strToRemove(urlStr, cityIOtableBaseUrl)
-		const geogridUrl = `${cityIOtableBaseUrl}${tableName}/GEOGRID/`
+      res.data.forEach((tableName) => {
+        const geogridUrl = `${cityIOtableBaseUrl}${tableName}/GEOGRID/`
         buttonsArr.push(
           <Button
             key={Math.random()}

--- a/src/Components/TableNameInput.js
+++ b/src/Components/TableNameInput.js
@@ -15,14 +15,6 @@ export default function TableNameInput({ setSelectedTable }) {
   const classes = useStyles()
   const [tableList, setTableList] = useState()
 
-  // https://stackoverflow.com/a/27098801/860099
-  function strToRemove(str, strToRemove) {
-    let start = str.indexOf(strToRemove)
-    let result =
-      str.slice(0, start) + str.slice(start + strToRemove.length, str.length)
-    return result
-  }
-
   useEffect(() => {
     /**
      * Gets all tables on init

--- a/src/Components/TableNameInput.js
+++ b/src/Components/TableNameInput.js
@@ -34,6 +34,7 @@ export default function TableNameInput({ setSelectedTable }) {
     axios.get(cityIOlistURL).then((res) => {
       res.data.forEach((urlStr) => {
         const tableName = strToRemove(urlStr, cityIOtableBaseUrl)
+		const geogridUrl = `${cityIOtableBaseUrl}${tableName}/GEOGRID/`
         buttonsArr.push(
           <Button
             key={Math.random()}
@@ -41,7 +42,7 @@ export default function TableNameInput({ setSelectedTable }) {
             color="secondary"
             onClick={() => {
               axios
-                .get(cityIOtableBaseUrl + tableName + '/GEOGRID')
+                .get(geogridUrl)
                 .then((res) => {
                   if (res.status === 200) {
                     setSelectedTable(tableName)

--- a/src/settings/settings.json
+++ b/src/settings/settings.json
@@ -2,8 +2,8 @@
   "docsURL": "https://raw.githubusercontent.com/CityScope/CS_cityscopeJS/master/docs/",
   "SOCKETS": { "URL": "ws://localhost:8080" },
   "cityIO": {
-    "baseURL": "https://cityiotest.mirage.city/api/table/",
-    "ListOfTables": "https://cityiotest.mirage.city/api/tables/list/",
+    "baseURL": "https://cityio.media.mit.edu/api/table/",
+    "ListOfTables": "https://cityio.media.mit.edu/api/tables/list/",
     "interval": 500,
     "cityIOmodules": [
       { "name": "header", "expectUpdate": false },

--- a/src/settings/settings.json
+++ b/src/settings/settings.json
@@ -2,8 +2,8 @@
   "docsURL": "https://raw.githubusercontent.com/CityScope/CS_cityscopeJS/master/docs/",
   "SOCKETS": { "URL": "ws://localhost:8080" },
   "cityIO": {
-    "baseURL": "https://cityio.media.mit.edu/api/table/",
-    "ListOfTables": "https://cityio.media.mit.edu/api/tables/list/",
+    "baseURL": "https://cityiotest.mirage.city/api/table/",
+    "ListOfTables": "https://cityiotest.mirage.city/api/tables/list/",
     "interval": 500,
     "cityIOmodules": [
       { "name": "header", "expectUpdate": false },

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -99,8 +99,7 @@ export const _postMapEditsToCityIO = (data, tableName, endPoint) => {
     expectUpdateModules.has(i),
   )
 
-  let postURL =
-    'https://cityio.media.mit.edu/api/table/update/' + tableName + endPoint
+  let postURL = settings.cityIO.baseURL + tableName + endPoint
 
   const options = {
     method: 'post',

--- a/src/views/CityIOviewer/CityIOdeckGLmap/SelectedTable/index.js
+++ b/src/views/CityIOviewer/CityIOdeckGLmap/SelectedTable/index.js
@@ -3,7 +3,11 @@ import { Typography, Link, Card, CardContent } from '@material-ui/core'
 export default function SelectedTable(props) {
   const clicked = props.clicked
   const cityscopeJSendpoint =
-    'https://cityscope.media.mit.edu/CS_cityscopeJS/?cityscope='
+    // 'https://cityscope.media.mit.edu/CS_cityscopeJS/?cityscope='
+
+	// use below for debugging 
+	'http://localhost:3000/CS_cityscopeJS/?cityscope='
+	
 console.log(clicked.object);
 
   return (

--- a/src/views/CityIOviewer/CityIOdeckGLmap/SelectedTable/index.js
+++ b/src/views/CityIOviewer/CityIOdeckGLmap/SelectedTable/index.js
@@ -3,10 +3,9 @@ import { Typography, Link, Card, CardContent } from '@material-ui/core'
 export default function SelectedTable(props) {
   const clicked = props.clicked
   const cityscopeJSendpoint =
-    // 'https://cityscope.media.mit.edu/CS_cityscopeJS/?cityscope='
+    'https://cityscope.media.mit.edu/CS_cityscopeJS/?cityscope='
 
-	// use below for debugging 
-	'http://localhost:3000/CS_cityscopeJS/?cityscope='
+	// 'http://localhost:3000/CS_cityscopeJS/?cityscope='
 	
 console.log(clicked.object);
 

--- a/src/views/CityIOviewer/CityIOlist.js
+++ b/src/views/CityIOviewer/CityIOlist.js
@@ -13,14 +13,15 @@ export default function CityIOlist() {
     // get all URLs
     const tablesArr = await axios.get(cityIOlistURL)
     // create array of all requests
-    const requestArr = tablesArr.data.map(async (urlStr) => {
-      const tableName = urlStr.split('/').pop()
+    const requestArr = tablesArr.data.map(async (tableName) => {
+      // const tableName = urlStr.split('/').pop()
+	  const url = `${settings.cityIO.baseURL}${tableName}/`;
       return axios
-        .get(urlStr + '/GEOGRID/properties/header')
+        .get(`${url}GEOGRID/properties/header/`)
         .then((res) =>
           setTableList((oldArray) => [
             ...oldArray,
-            { tableURL: urlStr, tableName: tableName, tableHeader: res.data },
+            { tableURL: url, tableName: tableName, tableHeader: res.data },
           ]),
         )
         .catch((error) => console.log(error.toString()))

--- a/src/views/CityScopeJS/CityIO/cityIO.js
+++ b/src/views/CityScopeJS/CityIO/cityIO.js
@@ -27,7 +27,7 @@ export default function CityIO(props) {
     const { tableName } = props;
     const [hashId, setHashId] = useState(null);
     const [hashes, setHashes] = useState({});
-    const cityioURL = `${settings.cityIO.baseURL}${tableName}`;
+    const cityioURL = `${settings.cityIO.baseURL}${tableName}/`;
     const cityioData = useSelector((state) => state.CITYIO);
 
     const dispatch = useDispatch();
@@ -44,7 +44,7 @@ export default function CityIO(props) {
 
     async function update() {
         // recursively get hashes
-        const newHashId = await getAPICall(cityioURL + "/meta/id");
+        const newHashId = await getAPICall(cityioURL + "meta/id/");
         if (hashId !== newHashId) {
             setHashId(newHashId);
         }
@@ -52,14 +52,14 @@ export default function CityIO(props) {
     }
 
     async function getModules() {
-        const newHashes = await getAPICall(cityioURL + "/meta/hashes");
+        const newHashes = await getAPICall(cityioURL + "meta/hashes/");
         const promises = [];
         const loadingModules = [];
         const pickedModules = settings.cityIO.cityIOmodules.map((x) => x.name);
         // for each of the modules in settings, add api call to promises
         pickedModules.forEach((module) => {
             if (hashes[module] !== newHashes[module]) {
-                promises.push(getAPICall(cityioURL + "/" + module));
+                promises.push(getAPICall(`${cityioURL}${module}/`));
                 loadingModules.push(module);
             } else {
                 promises.push(null);

--- a/src/views/CityScopeJS/CityIO/cityIO.js
+++ b/src/views/CityScopeJS/CityIO/cityIO.js
@@ -27,7 +27,7 @@ export default function CityIO(props) {
     const { tableName } = props;
     const [hashId, setHashId] = useState(null);
     const [hashes, setHashes] = useState({});
-    const cityioURL = settings.cityIO.baseURL + tableName;
+    const cityioURL = `${settings.cityIO.baseURL}${tableName}`;
     const cityioData = useSelector((state) => state.CITYIO);
 
     const dispatch = useDispatch();

--- a/src/views/CityScopeJS/CityIO/utils.js
+++ b/src/views/CityScopeJS/CityIO/utils.js
@@ -6,7 +6,7 @@ export const getScenarioIndices = (
     setScenarioNames,
     setLoadingState
 ) => {
-    var url = settings.cityIO.baseURL + tableName + "/meta/hashes";
+    var url = `${settings.cityIO.baseURL}${tableName}/meta/hashes`;
     axios
         .get(url)
         .then((res) => {
@@ -39,6 +39,6 @@ export const getScenarioIndices = (
 
 export const getScenarioName = (tableName, id) => {
     const url =
-        settings.cityIO.baseURL + tableName + "/scenarios" + id + "/info";
+		`${settings.cityIO.baseURL}${tableName}/scenarios${id}/info/`;
     return axios.get(url);
 };

--- a/src/views/CityScopeJS/MenuContainer/SaveMenu/components/SaveAsScenario/index.js
+++ b/src/views/CityScopeJS/MenuContainer/SaveMenu/components/SaveAsScenario/index.js
@@ -32,7 +32,7 @@ export default function SaveAsScenario(props) {
     const scenarioNames = useSelector((state) => state.SCENARIO_NAMES);
 
     const getScenarioIndex = () => {
-        var getURL = settings.cityIO.baseURL + tableName + "/meta/hashes";
+        var getURL = `${settings.cityIO.baseURL}${tableName}/meta/hashes/`;
         const options = {
             method: "get",
             url: getURL,
@@ -67,8 +67,7 @@ export default function SaveAsScenario(props) {
             },
         };
 
-        var postURL =
-            settings.cityIO.baseURL + "update/" + tableName + "/scenarios" + id;
+        var postURL = `${settings.cityIO.baseUR}update/${tableName}/scenarios${id}/`;
 
         const options = {
             method: "post",

--- a/src/views/CityScopeJS/MenuContainer/SaveMenu/components/ScenarioItems/index.js
+++ b/src/views/CityScopeJS/MenuContainer/SaveMenu/components/ScenarioItems/index.js
@@ -17,7 +17,7 @@ function ScenarioItems(props) {
     const dispatch = useDispatch();
 
     const getScenario = (tableName, id) => {
-        const getURL = settings.cityIO.baseURL + tableName + "/scenarios" + id;
+        const getURL = `${settings.cityIO.baseURL}${tableName}/scenarios${id}/`;
         const options = {
             method: "get",
             url: getURL,
@@ -42,7 +42,7 @@ function ScenarioItems(props) {
 
     const deleteScenario = (tableName, id) => {
         const getURL =
-            settings.cityIO.baseURL + "clear/" + tableName + "/scenarios" + id;
+		`${settings.cityIO.baseURL}clear/${tableName}/scenarios${id}/`
         const options = {
             method: "get",
             url: getURL,

--- a/src/views/GridEditor/EditorMenu/GridProps/CommitGrid/index.js
+++ b/src/views/GridEditor/EditorMenu/GridProps/CommitGrid/index.js
@@ -1,30 +1,29 @@
-import React from "react";
-import Button from "@material-ui/core/Button";
-import CloudUploadIcon from "@material-ui/icons/CloudUpload";
-import CloudDownloadIcon from "@material-ui/icons/CloudDownload";
-import axios from "axios";
-import settings from "../../../../../settings/GridEditorSettings.json";
-import globalSettings from "../../../../../settings/settings.json";
-import Typography from "@material-ui/core/Typography";
-import { useSelector } from "react-redux";
-import Link from "@material-ui/core/Link";
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import CloudUploadIcon from '@material-ui/icons/CloudUpload'
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
+import axios from 'axios'
+import settings from '../../../../../settings/GridEditorSettings.json'
+import globalSettings from '../../../../../settings/settings.json'
+import Typography from '@material-ui/core/Typography'
+import { useSelector } from 'react-redux'
+import Link from '@material-ui/core/Link'
 
 const reqResonseUI = (response, tableName) => {
-    let cityscopeJSendpoint =
-        "https://cityscope.media.mit.edu/CS_cityscopeJS/?cityscope=" +
-        tableName;
-    // create the feedback text
-    let resText = (
-        <Typography color="textPrimary" variant="caption">
-            CityIO is {response.data.status}. Grid deployed to{" "}
-            <Link color="textSecondary" href={cityscopeJSendpoint}>
-                {cityscopeJSendpoint}
-            </Link>
-        </Typography>
-    );
+  let cityscopeJSendpoint =
+    'https://cityscope.media.mit.edu/CS_cityscopeJS/?cityscope=' + tableName
+  // create the feedback text
+  let resText = (
+    <Typography color="textPrimary" variant="caption">
+      CityIO is {response.data.status}. Grid deployed to{' '}
+      <Link color="textSecondary" href={cityscopeJSendpoint}>
+        {cityscopeJSendpoint}
+      </Link>
+    </Typography>
+  )
 
-    return resText;
-};
+  return resText
+}
 
 /**
  *
@@ -32,55 +31,53 @@ const reqResonseUI = (response, tableName) => {
  *
  */
 const makeGEOGRIDobject = (struct, typesList, geoJsonFeatures, gridProps) => {
-    let GEOGRID_object = struct;
+  let GEOGRID_object = struct
 
-    // take types list and prepare to csJS format
-    let newTypesList = {};
+  // take types list and prepare to csJS format
+  let newTypesList = {}
 
-    typesList.forEach((oldType) => {
-        newTypesList[oldType.name] = oldType;
-        //material-table creates strings for these items
-        // so in first "Commit to cityIO", these must be turned into
-        // Json objects. On Second commit, these are already objects,
-        // hence the two conditions below
+  typesList.forEach((oldType) => {
+    newTypesList[oldType.name] = oldType
+    //material-table creates strings for these items
+    // so in first "Commit to cityIO", these must be turned into
+    // Json objects. On Second commit, these are already objects,
+    // hence the two conditions below
 
-        newTypesList[oldType.name].LBCS =
-            typeof oldType.LBCS == "string"
-                ? JSON.parse(oldType.LBCS)
-                : oldType.LBCS;
-        newTypesList[oldType.name].NAICS =
-            typeof oldType.NAICS == "string"
-                ? JSON.parse(oldType.NAICS)
-                : oldType.NAICS;
-    });
+    newTypesList[oldType.name].LBCS =
+      typeof oldType.LBCS == 'string' ? JSON.parse(oldType.LBCS) : oldType.LBCS
+    newTypesList[oldType.name].NAICS =
+      typeof oldType.NAICS == 'string'
+        ? JSON.parse(oldType.NAICS)
+        : oldType.NAICS
+  })
 
-    GEOGRID_object.properties.types = newTypesList;
+  GEOGRID_object.properties.types = newTypesList
 
-    // inject table props to grid
-    GEOGRID_object.properties.header = gridProps;
-    GEOGRID_object.properties.header.longitude = parseFloat(
-        GEOGRID_object.properties.header.longitude
-    );
-    GEOGRID_object.properties.header.latitude = parseFloat(
-        GEOGRID_object.properties.header.latitude
-    );
-    GEOGRID_object.properties.header.rotation = parseFloat(
-        GEOGRID_object.properties.header.rotation
-    );
-    GEOGRID_object.properties.header.nrows = parseFloat(
-        GEOGRID_object.properties.header.nrows
-    );
-    GEOGRID_object.properties.header.ncols = parseFloat(
-        GEOGRID_object.properties.header.ncols
-    );
-    GEOGRID_object.properties.header.cellSize = parseFloat(
-        GEOGRID_object.properties.header.cellSize
-    );
+  // inject table props to grid
+  GEOGRID_object.properties.header = gridProps
+  GEOGRID_object.properties.header.longitude = parseFloat(
+    GEOGRID_object.properties.header.longitude,
+  )
+  GEOGRID_object.properties.header.latitude = parseFloat(
+    GEOGRID_object.properties.header.latitude,
+  )
+  GEOGRID_object.properties.header.rotation = parseFloat(
+    GEOGRID_object.properties.header.rotation,
+  )
+  GEOGRID_object.properties.header.nrows = parseFloat(
+    GEOGRID_object.properties.header.nrows,
+  )
+  GEOGRID_object.properties.header.ncols = parseFloat(
+    GEOGRID_object.properties.header.ncols,
+  )
+  GEOGRID_object.properties.header.cellSize = parseFloat(
+    GEOGRID_object.properties.header.cellSize,
+  )
 
-    // lastly get the grid features
-    GEOGRID_object.features = geoJsonFeatures;
-    return GEOGRID_object;
-};
+  // lastly get the grid features
+  GEOGRID_object.features = geoJsonFeatures
+  return GEOGRID_object
+}
 
 /**
  *
@@ -88,141 +85,113 @@ const makeGEOGRIDobject = (struct, typesList, geoJsonFeatures, gridProps) => {
  *
  */
 const makeGEOGRIDDATAobject = (geoJsonFeatures) => {
-    let GEOGRIDDATA_object = [];
-    geoJsonFeatures.forEach((element) => {
-        GEOGRIDDATA_object.push(element.properties);
-    });
-    return GEOGRIDDATA_object;
-};
+  let GEOGRIDDATA_object = []
+  geoJsonFeatures.forEach((element) => {
+    GEOGRIDDATA_object.push(element.properties)
+  })
+  return GEOGRIDDATA_object
+}
 
 export default function CommitGrid(props) {
-    const [reqResonse, setReqResonse] = React.useState(null);
+  const [reqResonse, setReqResonse] = React.useState(null)
 
-    const reduxState = useSelector((state) => state);
-    const hasGrid = reduxState.GRID_CREATED;
+  const reduxState = useSelector((state) => state)
+  const hasGrid = reduxState.GRID_CREATED
 
-    const downloadObjectAsJson = () => {
-        let GEOGRIDstruct = settings.GEOGRID;
+  const downloadObjectAsJson = () => {
+    let GEOGRIDstruct = settings.GEOGRID
 
-        let typesList = reduxState.TYPES_LIST;
-        let geoJsonFeatures = reduxState.GRID_CREATED.features;
-        let gridProps = props.gridProps;
-        let GEOGRID_object = makeGEOGRIDobject(
-            GEOGRIDstruct,
-            typesList,
-            geoJsonFeatures,
-            gridProps
-        );
-        var dataStr =
-            "data:text/json;charset=utf-8," +
-            encodeURIComponent(JSON.stringify(GEOGRID_object));
-        var downloadAnchorNode = document.createElement("a");
-        downloadAnchorNode.setAttribute("href", dataStr);
-        downloadAnchorNode.setAttribute("download", "grid.json");
-        document.body.appendChild(downloadAnchorNode); // required for firefox
-        downloadAnchorNode.click();
-        downloadAnchorNode.remove();
-    };
+    let typesList = reduxState.TYPES_LIST
+    let geoJsonFeatures = reduxState.GRID_CREATED.features
+    let gridProps = props.gridProps
+    let GEOGRID_object = makeGEOGRIDobject(
+      GEOGRIDstruct,
+      typesList,
+      geoJsonFeatures,
+      gridProps,
+    )
+    var dataStr =
+      'data:text/json;charset=utf-8,' +
+      encodeURIComponent(JSON.stringify(GEOGRID_object))
+    var downloadAnchorNode = document.createElement('a')
+    downloadAnchorNode.setAttribute('href', dataStr)
+    downloadAnchorNode.setAttribute('download', 'grid.json')
+    document.body.appendChild(downloadAnchorNode) // required for firefox
+    downloadAnchorNode.click()
+    downloadAnchorNode.remove()
+  }
 
-    const postGridToCityIO = () => {
-        let GEOGRIDstruct = settings.GEOGRID;
-        let typesList = reduxState.TYPES_LIST;
-        let geoJsonFeatures = reduxState.GRID_CREATED.features;
-        let gridProps = props.gridProps;
-        // take grid struct from settings
-        let GEOGRID_object = makeGEOGRIDobject(
-            GEOGRIDstruct,
-            typesList,
-            geoJsonFeatures,
-            gridProps
-        );
+  const postGridToCityIO = () => {
+    let GEOGRIDstruct = settings.GEOGRID
+    let typesList = reduxState.TYPES_LIST
+    let geoJsonFeatures = reduxState.GRID_CREATED.features
+    let gridProps = props.gridProps
+    // take grid struct from settings
+    let GEOGRID_object = makeGEOGRIDobject(
+      GEOGRIDstruct,
+      typesList,
+      geoJsonFeatures,
+      gridProps,
+    )
 
-        let GEOGRIDDATA_object = makeGEOGRIDDATAobject(geoJsonFeatures);
+    let GEOGRIDDATA_object = makeGEOGRIDDATAobject(geoJsonFeatures)
+    let tableName = GEOGRID_object.properties.header.tableName.toLowerCase()
 
-        let tableName = GEOGRID_object.properties.header.tableName.toLowerCase();
-        let requestsList = {
-            geoGridURL:
-				`${globalSettings.cityIO.baseURL}${tableName}/GEOGRID/`,
+    const geoGridOptions = (URL, DATA) => {
+      return {
+        method: 'post',
+        url: URL,
+        data: DATA,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      }
+    }
 
-            geoGridDataURL:
-				`${globalSettings.cityIO.baseURL}${tableName}/GEOGRIDDATA/`,
-        };
+    const table_url = `${globalSettings.cityIO.baseURL}${tableName}/`
+    const new_table_grid = {
+      GEOGRID: GEOGRID_object,
+      GEOGRIDDATA: GEOGRIDDATA_object,
+    }
 
-        const geoGridOptions = (URL, DATA) => {
-            return {
-                method: "post",
-                url: URL,
-                data: DATA,
-                headers: {
-                    "Content-Type": "application/json",
-                    Accept: "application/json",
-                },
-            };
-        };
+    axios(geoGridOptions(table_url, new_table_grid))
+      .then(function (response) {
+        setReqResonse(reqResonseUI(response, tableName))
+      })
+      .catch((error) => console.log(`ERROR: ${error}`))
+  }
 
-		const table_url = `${globalSettings.cityIO.baseURL}${tableName}/`;
-		const new_table_grid = {
-			"GEOGRID": GEOGRID_object,
-			"GEOGRIDDATA": GEOGRIDDATA_object
-		};
-
-		axios(geoGridOptions(table_url, new_table_grid))
-		.catch(error => console.log(`ERROR: ${error}`));
-
-        // axios(geoGridOptions(requestsList.geoGridURL, GEOGRID_object))
-        //     .then(function (response) {
-        //         setReqResonse(reqResonseUI(response, tableName));
-        //     })
-        //     // then reset GEOGRIDDATA of that new grid
-
-        //     .then(function () {
-        //         axios(geoGridOptions(requestsList.geoGridDataURL, {}));
-        //         console.log("removed GEOGRIDDATA");
-        //     })
-        //     .then(function () {
-        //         axios(
-        //             geoGridOptions(
-        //                 requestsList.geoGridDataURL,
-        //                 GEOGRIDDATA_object
-        //             )
-        //         );
-        //         console.log("mirrored GEOGRID to GEOGRIDDATA");
-        //     })
-        //     .catch((error) => {
-        //         console.log("ERROR:", error);
-        //     });
-    };
-
-    return (
+  return (
+    <>
+      {hasGrid && (
         <>
-            {hasGrid && (
-                <>
-                    <Button
-                        onClick={() => {
-                            postGridToCityIO();
-                        }}
-                        variant="outlined"
-                        color="default"
-                        startIcon={<CloudUploadIcon />}
-                    >
-                        Commit Grid to cityIO
-                    </Button>
+          <Button
+            onClick={() => {
+              postGridToCityIO()
+            }}
+            variant="outlined"
+            color="default"
+            startIcon={<CloudUploadIcon />}
+          >
+            Commit Grid to cityIO
+          </Button>
 
-                    <Button
-                        onClick={() => {
-                            // ! download as json
-                            downloadObjectAsJson();
-                        }}
-                        variant="outlined"
-                        color="default"
-                        startIcon={<CloudDownloadIcon />}
-                    >
-                        Download JSON
-                    </Button>
+          <Button
+            onClick={() => {
+              // ! download as json
+              downloadObjectAsJson()
+            }}
+            variant="outlined"
+            color="default"
+            startIcon={<CloudDownloadIcon />}
+          >
+            Download JSON
+          </Button>
 
-                    <div style={{ width: "100%" }}> {reqResonse}</div>
-                </>
-            )}
+          <div style={{ width: '100%' }}> {reqResonse}</div>
         </>
-    );
+      )}
+    </>
+  )
 }

--- a/src/views/GridEditor/EditorMenu/GridProps/CommitGrid/index.js
+++ b/src/views/GridEditor/EditorMenu/GridProps/CommitGrid/index.js
@@ -142,14 +142,10 @@ export default function CommitGrid(props) {
         let tableName = GEOGRID_object.properties.header.tableName.toLowerCase();
         let requestsList = {
             geoGridURL:
-				globalSettings.cityIO.baseURL +
-                tableName +
-                "/GEOGRID",
+				`${globalSettings.cityIO.baseURL}${tableName}/GEOGRID/`,
 
             geoGridDataURL:
-				globalSettings.cityIO.baseURL + 
-                tableName +
-                "/GEOGRIDDATA",
+				`${globalSettings.cityIO.baseURL}${tableName}/GEOGRIDDATA/`,
         };
 
         const geoGridOptions = (URL, DATA) => {
@@ -164,28 +160,37 @@ export default function CommitGrid(props) {
             };
         };
 
-        axios(geoGridOptions(requestsList.geoGridURL, GEOGRID_object))
-            .then(function (response) {
-                setReqResonse(reqResonseUI(response, tableName));
-            })
-            // then reset GEOGRIDDATA of that new grid
+		const table_url = `${globalSettings.cityIO.baseURL}${tableName}/`;
+		const new_table_grid = {
+			"GEOGRID": GEOGRID_object,
+			"GEOGRIDDATA": GEOGRIDDATA_object
+		};
 
-            .then(function () {
-                axios(geoGridOptions(requestsList.geoGridDataURL, {}));
-                console.log("removed GEOGRIDDATA");
-            })
-            .then(function () {
-                axios(
-                    geoGridOptions(
-                        requestsList.geoGridDataURL,
-                        GEOGRIDDATA_object
-                    )
-                );
-                console.log("mirrored GEOGRID to GEOGRIDDATA");
-            })
-            .catch((error) => {
-                console.log("ERROR:", error);
-            });
+		axios(geoGridOptions(table_url, new_table_grid))
+		.catch(error => console.log(`ERROR: ${error}`));
+
+        // axios(geoGridOptions(requestsList.geoGridURL, GEOGRID_object))
+        //     .then(function (response) {
+        //         setReqResonse(reqResonseUI(response, tableName));
+        //     })
+        //     // then reset GEOGRIDDATA of that new grid
+
+        //     .then(function () {
+        //         axios(geoGridOptions(requestsList.geoGridDataURL, {}));
+        //         console.log("removed GEOGRIDDATA");
+        //     })
+        //     .then(function () {
+        //         axios(
+        //             geoGridOptions(
+        //                 requestsList.geoGridDataURL,
+        //                 GEOGRIDDATA_object
+        //             )
+        //         );
+        //         console.log("mirrored GEOGRID to GEOGRIDDATA");
+        //     })
+        //     .catch((error) => {
+        //         console.log("ERROR:", error);
+        //     });
     };
 
     return (

--- a/src/views/GridEditor/EditorMenu/GridProps/CommitGrid/index.js
+++ b/src/views/GridEditor/EditorMenu/GridProps/CommitGrid/index.js
@@ -4,6 +4,7 @@ import CloudUploadIcon from "@material-ui/icons/CloudUpload";
 import CloudDownloadIcon from "@material-ui/icons/CloudDownload";
 import axios from "axios";
 import settings from "../../../../../settings/GridEditorSettings.json";
+import globalSettings from "../../../../../settings/settings.json";
 import Typography from "@material-ui/core/Typography";
 import { useSelector } from "react-redux";
 import Link from "@material-ui/core/Link";
@@ -141,12 +142,12 @@ export default function CommitGrid(props) {
         let tableName = GEOGRID_object.properties.header.tableName.toLowerCase();
         let requestsList = {
             geoGridURL:
-                "https://cityio.media.mit.edu/api/table/update/" +
+				globalSettings.cityIO.baseURL +
                 tableName +
                 "/GEOGRID",
 
             geoGridDataURL:
-                "https://cityio.media.mit.edu/api/table/update/" +
+				globalSettings.cityIO.baseURL + 
                 tableName +
                 "/GEOGRIDDATA",
         };

--- a/src/views/ProjectionMapping/CityIO/index.js
+++ b/src/views/ProjectionMapping/CityIO/index.js
@@ -42,7 +42,7 @@ export default function CityIO(props) {
 
     async function update() {
         // recursively get hashes
-        const newHashId = await getAPICall(cityioURL + "/meta/id");
+        const newHashId = await getAPICall(cityioURL + "/meta/id/");
         if (hashId !== newHashId) {
             setHashId(newHashId);
         }
@@ -50,14 +50,14 @@ export default function CityIO(props) {
     }
 
     async function getModules() {
-        const newHashes = await getAPICall(cityioURL + "/meta/hashes");
+        const newHashes = await getAPICall(cityioURL + "/meta/hashes/");
         const promises = [];
         const loadingModules = [];
         const pickedModules = settings.cityIO.cityIOmodules.map((x) => x.name);
         // for each of the modules in settings, add api call to promises
         pickedModules.forEach((module) => {
             if (hashes[module] !== newHashes[module]) {
-                promises.push(getAPICall(cityioURL + "/" + module));
+                promises.push(getAPICall(`${cityioURL}/${module}/`));
                 loadingModules.push(module);
             } else {
                 promises.push(null);

--- a/src/views/ProjectionMapping/CityIO/index.js
+++ b/src/views/ProjectionMapping/CityIO/index.js
@@ -25,7 +25,7 @@ export default function CityIO(props) {
     const { tableName } = props;
     const [hashId, setHashId] = useState(null);
     const [hashes, setHashes] = useState({});
-    const cityioURL = settings.cityIO.baseURL + tableName;
+    const cityioURL = `${settings.cityIO.baseURL}${tableName}/`;
     const cityioData = useSelector((state) => state.CITYIO);
 
     const dispatch = useDispatch();


### PR DESCRIPTION
This PR prepares for the new cityio server.

*This is not compatible to the the current version. Only apply this after cityio.media.mit.edu has migrated....*

three commits:

c95378e : centralizes endpoint URLs
so we only need to edit one place if we want to point to the test server. Should be "no harm commit."

ad339ad : main commit to incorporate changes of the new cityio version.
It points to `https://cityiotest.mirage.city` and `localhost:3000` where needed.

65c7a5c : reverts the URL to `https://cityio.media.mit.edu` and `https://cityscope.media.mit.edu`.

