### PR TITLE
Improve the style of scrollbar and delete an unexpected character

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,6 @@ ReactDOM.render(
         <App />
       </HashRouter>
     </Provider>
-    ,
   </>,
 
   document.getElementById("root")

--- a/src/theme/GlobalStyles.js
+++ b/src/theme/GlobalStyles.js
@@ -7,6 +7,30 @@ const useStyles = makeStyles(() =>
                 boxSizing: "border-box",
                 margin: 0,
                 padding: 0,
+
+                //  Style for ScrollBar
+                scrollbarColor: "#6b6b6b #18191a",
+                "&::-webkit-scrollbar, & *::-webkit-scrollbar": {
+                  backgroundColor: "#18191a",
+                },
+                "&::-webkit-scrollbar-thumb, & *::-webkit-scrollbar-thumb": {
+                  borderRadius: 8,
+                  backgroundColor: "#6b6b6b",
+                  minHeight: 24,
+                  border: "3px solid #18191a",
+                },
+                "&::-webkit-scrollbar-thumb:focus, & *::-webkit-scrollbar-thumb:focus": {
+                  backgroundColor: "#959595",
+                },
+                "&::-webkit-scrollbar-thumb:active, & *::-webkit-scrollbar-thumb:active": {
+                  backgroundColor: "#959595",
+                },
+                "&::-webkit-scrollbar-thumb:hover, & *::-webkit-scrollbar-thumb:hover": {
+                  backgroundColor: "#959595",
+                },
+                "&::-webkit-scrollbar-corner, & *::-webkit-scrollbar-corner": {
+                  backgroundColor: "#18191a",
+                },
             },
             html: {
                 "-webkit-font-smoothing": "antialiased",

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,7 +1,7 @@
-import { createTheme, colors } from '@material-ui/core'
+import { createMuiTheme, colors } from '@material-ui/core'
 import typography from './typography'
 
-const theme = createTheme({
+const theme = createMuiTheme({
   zIndex: {
     appBar: 999,
   },

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,7 +1,7 @@
-import { createMuiTheme, colors } from '@material-ui/core'
+import { createTheme, colors } from '@material-ui/core'
 import typography from './typography'
 
-const theme = createMuiTheme({
+const theme = createTheme({
   zIndex: {
     appBar: 999,
   },
@@ -48,7 +48,6 @@ const theme = createMuiTheme({
         },
       },
     },
-
     MuiOutlinedInput: {
       notchedOutline: {
         borderColor: '#ff5278',
@@ -63,7 +62,6 @@ const theme = createMuiTheme({
         opacity: 0.1,
       },
     },
-
     MuiCard: {
       root: {
         boxShadow:


### PR DESCRIPTION
As the default style of Scrollbar looks bad with material UI, I added a global custom style for Scrollbar.
In addition, I deleted an unexpected character in src/index.js, which caused a wrong page height.